### PR TITLE
Team member and user information can be viewed from the Team Screen

### DIFF
--- a/app/src/main/java/com/carkzis/ananke/navigation/AnankeNavHost.kt
+++ b/app/src/main/java/com/carkzis/ananke/navigation/AnankeNavHost.kt
@@ -53,7 +53,8 @@ fun AnankeNavHost(
             TeamRoute(
                 onOutOfGame = {
                     navController.navigateUp()
-                }
+                },
+                onShowSnackbar = onShowSnackbar
             )
         }
         composable(route = AnankeDestination.YOU.toString()) {

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/nugame/NewGameRoute.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/nugame/NewGameRoute.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.carkzis.ananke.data.model.NewGame
 import java.util.UUID
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun NewGameRoute(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
@@ -5,5 +5,5 @@ import com.carkzis.ananke.data.model.User
 
 sealed class TeamEvent {
     data class TeamMemberDialogueShow(val teamMember: User, val character: GameCharacter) : TeamEvent()
-    data object TeamMemberDialogueDismiss : TeamEvent()
+    data object TeamMemberDialogueHidden : TeamEvent()
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
@@ -5,6 +5,6 @@ import com.carkzis.ananke.data.model.User
 
 sealed class TeamEvent {
     data class TeamMemberDialogueShow(val teamMember: User, val character: GameCharacter) : TeamEvent()
-    data object CloseDialogue : TeamEvent()
     data class UserDialogueShow(val user: User) : TeamEvent()
+    data object CloseDialogue : TeamEvent()
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
@@ -5,5 +5,6 @@ import com.carkzis.ananke.data.model.User
 
 sealed class TeamEvent {
     data class TeamMemberDialogueShow(val teamMember: User, val character: GameCharacter) : TeamEvent()
-    data object TeamMemberDialogueHidden : TeamEvent()
+    data object CloseDialogue : TeamEvent()
+    data class UserDialogueShow(val user: User) : TeamEvent()
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamEvent.kt
@@ -1,0 +1,9 @@
+package com.carkzis.ananke.ui.screens.team
+
+import com.carkzis.ananke.data.model.GameCharacter
+import com.carkzis.ananke.data.model.User
+
+sealed class TeamEvent {
+    data class TeamMemberDialogueShow(val teamMember: User, val character: GameCharacter) : TeamEvent()
+    data object TeamMemberDialogueDismiss : TeamEvent()
+}

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
@@ -38,8 +38,11 @@ fun TeamRoute(
         onViewTeamMember = { teamMember ->
             viewModel.viewCharacterForTeamMember(teamMember)
         },
+        onViewUser = { user ->
+            viewModel.viewUser(user)
+        },
         onDismissDialogue = {
-            viewModel.closeTeamMemberDialogue()
+            viewModel.closeDialogue()
         },
     )
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
@@ -19,6 +19,7 @@ fun TeamRoute(
     val gameState by viewModel.gamingState.collectAsStateWithLifecycle()
     val availableUsers by viewModel.potentialTeamMemberList.collectAsStateWithLifecycle()
     val teamMembers by viewModel.currentTeamMembers.collectAsStateWithLifecycle()
+    val events by viewModel.event.collectAsStateWithLifecycle()
 
     if (gameState == GamingState.OutOfGame) {
         onOutOfGame()
@@ -30,8 +31,12 @@ fun TeamRoute(
         gamingState = gameState,
         users = availableUsers,
         teamMembers = teamMembers,
+        event = events,
         onAddUser = { user ->
             viewModel.addTeamMember(user, currentGame.toGame())
+        },
+        onViewTeamMember = { teamMember ->
+            viewModel.viewCharacterForTeamMember(teamMember)
         }
     )
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
@@ -14,6 +14,7 @@ fun TeamRoute(
     modifier: Modifier = Modifier,
     viewModel: TeamViewModel = hiltViewModel(),
     onOutOfGame: () -> Unit,
+    onShowSnackbar: suspend (String) -> Boolean,
 ) {
     val currentGame by viewModel.currentGame.collectAsStateWithLifecycle(CurrentGame.EMPTY)
     val gameState by viewModel.gamingState.collectAsStateWithLifecycle()
@@ -44,5 +45,10 @@ fun TeamRoute(
         onDismissDialogue = {
             viewModel.closeDialogue()
         },
+        onShowSnackbar = {
+            viewModel.message.collect {
+                onShowSnackbar(it)
+            }
+        }
     )
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamRoute.kt
@@ -37,6 +37,9 @@ fun TeamRoute(
         },
         onViewTeamMember = { teamMember ->
             viewModel.viewCharacterForTeamMember(teamMember)
-        }
+        },
+        onDismissDialogue = {
+            viewModel.closeTeamMemberDialogue()
+        },
     )
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
@@ -1,8 +1,11 @@
 package com.carkzis.ananke.ui.screens.team
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -17,16 +20,21 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.carkzis.ananke.data.model.CurrentGame
 import com.carkzis.ananke.data.model.User
 import com.carkzis.ananke.navigation.AnankeDestination
+import com.carkzis.ananke.ui.components.AnankeButton
 import com.carkzis.ananke.ui.components.AnankeText
 import com.carkzis.ananke.ui.screens.game.GamingState
 import com.carkzis.ananke.ui.theme.AnankeTheme
@@ -42,12 +50,22 @@ fun TeamScreen(
     event: TeamEvent = TeamEvent.TeamMemberDialogueHidden,
     onAddUser: (User) -> Unit = {},
     onViewTeamMember: (User) -> Unit = {},
+    onDismissDialogue: () -> Unit = {},
 ) {
     when (gamingState) {
         is GamingState.Loading -> {}
         is GamingState.OutOfGame -> {}
         is GamingState.InGame -> {
-            InGameTeamScreen(modifier, currentGame, teamMembers, users, onAddUser, onViewTeamMember, event)
+            InGameTeamScreen(
+                modifier,
+                currentGame,
+                teamMembers,
+                users,
+                onAddUser,
+                onViewTeamMember,
+                onDismissDialogue,
+                event
+            )
         }
     }
 }
@@ -60,17 +78,57 @@ private fun InGameTeamScreen(
     users: List<User>,
     onAddUser: (User) -> Unit,
     onViewTeamMember: (User) -> Unit,
+    onDismissDialogue: () -> Unit,
     event: TeamEvent = TeamEvent.TeamMemberDialogueHidden
 ) {
+    if (event is TeamEvent.TeamMemberDialogueShow) {
+        // TODO: Make this look good.
+        Timber.e("TeamMemberDialogueShow: ${event.teamMember.name} - ${event.character.character}")
+        Dialog(
+            onDismissRequest = onDismissDialogue,
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false
+            )
+        ) {
+            Card(
+                modifier = modifier
+                    .padding(16.dp)
+                    .fillMaxSize()
+                    .testTag("${AnankeDestination.TEAM}-team-member-dialogue"),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text("Name: ${event.teamMember.name}")
+                    Text("Character: ${event.character.character}")
+                    Text("Bio: ${event.character.bio}")
+                    AnankeButton(onClick = onDismissDialogue) {
+                        AnankeText(
+                            text = "Close",
+                            modifier = modifier
+                                .padding(8.dp)
+                                .testTag("${AnankeDestination.TEAM}-team-member-dialogue-close-button"),
+                            textStyle = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     val lazyListState = rememberLazyListState()
     LazyColumn(
         modifier = modifier.testTag("${AnankeDestination.TEAM}-team-column"),
         lazyListState
     ) {
-        if (event is TeamEvent.TeamMemberDialogueShow) {
-            Timber.e("TeamMemberDialogueShow: ${event.teamMember.name} - ${event.character.character}")
-        }
-
         teamScreenTitle(modifier)
         currentGameTitle(currentGame, modifier)
         teamMembers(modifier, teamMembers, onViewTeamMember)

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
@@ -383,6 +383,7 @@ private fun TeamMemberCardBox(
     Box(
         modifier = modifier
             .padding(16.dp)
+            .testTag("${AnankeDestination.TEAM}-tm-card-box")
             .clickable {
                 onViewTeamMember(user)
             }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -50,7 +51,12 @@ fun TeamScreen(
     onViewTeamMember: (User) -> Unit = {},
     onViewUser: (User) -> Unit = {},
     onDismissDialogue: () -> Unit = {},
+    onShowSnackbar: suspend () -> Unit = {}
 ) {
+    LaunchedEffect(Unit) {
+        onShowSnackbar()
+    }
+
     when (gamingState) {
         is GamingState.Loading -> {}
         is GamingState.OutOfGame -> {}
@@ -512,7 +518,7 @@ private fun TeamScreenWithTeamMembersPreview() {
             teamMembers = listOf(
                 User(id = 1, name = "Zidun"),
                 User(id = 2, name = "Vivu")
-            )
+            ),
         )
     }
 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
@@ -442,9 +442,6 @@ private fun UserCardBox(
     Box(
         modifier = modifier
             .padding(16.dp)
-            .clickable {
-                onViewUser(user)
-            }
     ) {
         Row {
             Icon(
@@ -458,7 +455,10 @@ private fun UserCardBox(
                 modifier = modifier
                     .align(CenterVertically)
                     .weight(1f)
-                    .testTag("${AnankeDestination.TEAM}-user-name"),
+                    .testTag("${AnankeDestination.TEAM}-user-name")
+                    .clickable {
+                        onViewUser(user)
+                    },
                 textStyle = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center
             )

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamScreen.kt
@@ -1,7 +1,6 @@
 package com.carkzis.ananke.ui.screens.team
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,7 +19,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
@@ -32,13 +30,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.carkzis.ananke.data.model.CurrentGame
+import com.carkzis.ananke.data.model.GameCharacter
 import com.carkzis.ananke.data.model.User
 import com.carkzis.ananke.navigation.AnankeDestination
 import com.carkzis.ananke.ui.components.AnankeButton
 import com.carkzis.ananke.ui.components.AnankeText
 import com.carkzis.ananke.ui.screens.game.GamingState
 import com.carkzis.ananke.ui.theme.AnankeTheme
-import timber.log.Timber
 
 @Composable
 fun TeamScreen(
@@ -82,46 +80,7 @@ private fun InGameTeamScreen(
     event: TeamEvent = TeamEvent.TeamMemberDialogueHidden
 ) {
     if (event is TeamEvent.TeamMemberDialogueShow) {
-        // TODO: Make this look good.
-        Timber.e("TeamMemberDialogueShow: ${event.teamMember.name} - ${event.character.character}")
-        Dialog(
-            onDismissRequest = onDismissDialogue,
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false
-            )
-        ) {
-            Card(
-                modifier = modifier
-                    .padding(16.dp)
-                    .fillMaxSize()
-                    .testTag("${AnankeDestination.TEAM}-team-member-dialogue"),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                ),
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    Text("Name: ${event.teamMember.name}")
-                    Text("Character: ${event.character.character}")
-                    Text("Bio: ${event.character.bio}")
-                    AnankeButton(onClick = onDismissDialogue) {
-                        AnankeText(
-                            text = "Close",
-                            modifier = modifier
-                                .padding(8.dp)
-                                .testTag("${AnankeDestination.TEAM}-team-member-dialogue-close-button"),
-                            textStyle = MaterialTheme.typography.bodyLarge
-                        )
-                    }
-                }
-            }
-        }
+        TeamMemberDialogue(onDismissDialogue, modifier, event)
     }
 
     val lazyListState = rememberLazyListState()
@@ -133,6 +92,92 @@ private fun InGameTeamScreen(
         currentGameTitle(currentGame, modifier)
         teamMembers(modifier, teamMembers, onViewTeamMember)
         availableUsers(modifier, users, onAddUser)
+    }
+}
+
+@Composable
+private fun TeamMemberDialogue(
+    onDismissDialogue: () -> Unit,
+    modifier: Modifier,
+    event: TeamEvent.TeamMemberDialogueShow
+) {
+    Dialog(
+        onDismissRequest = onDismissDialogue,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Card(
+            modifier = modifier
+                .padding(16.dp)
+                .fillMaxSize()
+                .testTag("${AnankeDestination.TEAM}-team-member-dialogue"),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            ),
+        ) {
+            AnankeText(
+                text = "Team Member",
+                modifier = modifier
+                    .padding(top = 32.dp)
+                    .testTag("${AnankeDestination.TEAM}-team-member-dialogue-title"),
+                textStyle = MaterialTheme.typography.headlineLarge
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                AnankeText(
+                    text = "Name",
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.titleLarge
+                )
+                AnankeText(
+                    text = event.teamMember.name,
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.bodyLarge
+                )
+                AnankeText(
+                    text = "Character",
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.titleLarge
+                )
+                AnankeText(
+                    text = event.character.character,
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.bodyLarge
+                )
+                AnankeText(
+                    text = "Bio",
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.titleLarge
+                )
+                AnankeText(
+                    text = event.character.bio.ifEmpty { "No bio available." },
+                    modifier = modifier
+                        .padding(8.dp),
+                    textStyle = MaterialTheme.typography.bodyLarge
+                )
+
+                AnankeButton(onClick = onDismissDialogue) {
+                    AnankeText(
+                        text = "Close",
+                        modifier = modifier
+                            .padding(8.dp)
+                            .testTag("${AnankeDestination.TEAM}-team-member-dialogue-close-button"),
+                        textStyle = MaterialTheme.typography.bodyLarge
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -391,6 +436,26 @@ private fun TeamScreenWithTeamMembersPreview() {
             teamMembers = listOf(
                 User(id = 1, name = "Zidun"),
                 User(id = 2, name = "Vivu")
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TeamMemberDialoguePreview() {
+    AnankeTheme {
+        TeamMemberDialogue(
+            onDismissDialogue = {},
+            modifier = Modifier,
+            event = TeamEvent.TeamMemberDialogueShow(
+                teamMember = User(id = 1, name = "Zidun"),
+                character = GameCharacter(
+                    id = "1",
+                    userName = "Marc",
+                    character = "Zidun",
+                    bio = "This is a test character.",
+                )
             )
         )
     }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
@@ -71,7 +71,7 @@ class TeamViewModel @Inject constructor(
     private val _message = MutableSharedFlow<String>()
     val message = _message.asSharedFlow()
 
-    private val _event = MutableStateFlow<TeamEvent>(TeamEvent.TeamMemberDialogueHidden)
+    private val _event = MutableStateFlow<TeamEvent>(TeamEvent.CloseDialogue)
     val event = _event.asStateFlow()
 
     init {
@@ -109,9 +109,15 @@ class TeamViewModel @Inject constructor(
         }
     }
 
-    fun closeTeamMemberDialogue() {
+    fun closeDialogue() {
         viewModelScope.launch {
-            _event.emit(TeamEvent.TeamMemberDialogueHidden)
+            _event.emit(TeamEvent.CloseDialogue)
+        }
+    }
+
+    fun viewUser(user: User) {
+        viewModelScope.launch {
+            _event.emit(TeamEvent.UserDialogueShow(user))
         }
     }
 

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
@@ -109,15 +109,15 @@ class TeamViewModel @Inject constructor(
         }
     }
 
-    fun closeDialogue() {
-        viewModelScope.launch {
-            _event.emit(TeamEvent.CloseDialogue)
-        }
-    }
-
     fun viewUser(user: User) {
         viewModelScope.launch {
             _event.emit(TeamEvent.UserDialogueShow(user))
+        }
+    }
+
+    fun closeDialogue() {
+        viewModelScope.launch {
+            _event.emit(TeamEvent.CloseDialogue)
         }
     }
 

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
@@ -8,6 +8,7 @@ import com.carkzis.ananke.data.model.User
 import com.carkzis.ananke.data.repository.TeamRepository
 import com.carkzis.ananke.ui.screens.game.GamingState
 import com.carkzis.ananke.utils.AddCurrentUserToTheirEmptyGameUseCase
+import com.carkzis.ananke.utils.AddTeamMemberUseCase
 import com.carkzis.ananke.utils.CheckGameExistsUseCase
 import com.carkzis.ananke.utils.GameStateUseCase
 import com.carkzis.ananke.utils.ValidatorResponse
@@ -27,6 +28,7 @@ import javax.inject.Inject
 class TeamViewModel @Inject constructor(
     gameStateUseCase: GameStateUseCase,
     addCurrentUserToTheirEmptyGameUseCase: AddCurrentUserToTheirEmptyGameUseCase,
+    private val addTeamMemberUseCase: AddTeamMemberUseCase,
     private val checkGameExistsUseCase: CheckGameExistsUseCase,
     private val teamRepository: TeamRepository
 ) : ViewModel() {
@@ -79,7 +81,7 @@ class TeamViewModel @Inject constructor(
             try {
                 checkGameExistsUseCase.invoke(game).collect {
                     when (it) {
-                        is ValidatorResponse.Pass -> teamRepository.addTeamMember(teamMember, game.id.toLong())
+                        is ValidatorResponse.Pass -> addTeamMemberUseCase(teamMember, game.id.toLong())
                         is ValidatorResponse.Fail -> _message.emit(it.failureMessage)
                     }
                 }

--- a/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
+++ b/app/src/main/java/com/carkzis/ananke/ui/screens/team/TeamViewModel.kt
@@ -71,7 +71,7 @@ class TeamViewModel @Inject constructor(
     private val _message = MutableSharedFlow<String>()
     val message = _message.asSharedFlow()
 
-    private val _event = MutableStateFlow<TeamEvent>(TeamEvent.TeamMemberDialogueDismiss)
+    private val _event = MutableStateFlow<TeamEvent>(TeamEvent.TeamMemberDialogueHidden)
     val event = _event.asStateFlow()
 
     init {
@@ -106,6 +106,12 @@ class TeamViewModel @Inject constructor(
             val currentGameId = currentGame.first().id
             val gameCharacter = userCharacterUseCase(teamMember, currentGameId.toLong())
             _event.emit(TeamEvent.TeamMemberDialogueShow(teamMember, gameCharacter))
+        }
+    }
+
+    fun closeTeamMemberDialogue() {
+        viewModelScope.launch {
+            _event.emit(TeamEvent.TeamMemberDialogueHidden)
         }
     }
 

--- a/app/src/main/java/com/carkzis/ananke/utils/AddTeamMemberUseCase.kt
+++ b/app/src/main/java/com/carkzis/ananke/utils/AddTeamMemberUseCase.kt
@@ -1,0 +1,23 @@
+package com.carkzis.ananke.utils
+
+import com.carkzis.ananke.data.model.NewCharacter
+import com.carkzis.ananke.data.model.User
+import com.carkzis.ananke.data.repository.TeamRepository
+import com.carkzis.ananke.data.repository.YouRepository
+import javax.inject.Inject
+
+class AddTeamMemberUseCase @Inject constructor(
+    private val teamRepository: TeamRepository,
+    private val youRepository: YouRepository
+) {
+    suspend operator fun invoke(teamMember: User, currentGameId: Long) {
+        teamRepository.addTeamMember(teamMember, currentGameId)
+
+        youRepository.addNewCharacter(
+            NewCharacter(
+                userId = teamMember.id,
+                gameId = currentGameId,
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/carkzis/ananke/utils/UserCharacterUseCase.kt
+++ b/app/src/main/java/com/carkzis/ananke/utils/UserCharacterUseCase.kt
@@ -1,0 +1,13 @@
+package com.carkzis.ananke.utils
+
+import com.carkzis.ananke.data.model.User
+import com.carkzis.ananke.data.repository.YouRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class UserCharacterUseCase @Inject constructor(
+    private val youRepository: YouRepository
+) {
+    suspend operator fun invoke(user: User, gameId: Long) =
+        youRepository.getCharacterForUser(user, gameId).first()
+}

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -40,7 +40,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -31,6 +31,7 @@ import com.carkzis.ananke.ui.screens.team.TeamRoute
 import com.carkzis.ananke.ui.screens.team.TeamScreen
 import com.carkzis.ananke.ui.screens.team.TeamViewModel
 import com.carkzis.ananke.utils.AddCurrentUserToTheirEmptyGameUseCase
+import com.carkzis.ananke.utils.AddTeamMemberUseCase
 import com.carkzis.ananke.utils.CheckGameExistsUseCase
 import com.carkzis.ananke.utils.GameStateUseCase
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -251,6 +252,7 @@ class TeamScreenTest {
         val viewModel = TeamViewModel(
             GameStateUseCase(gameRepository),
             AddCurrentUserToTheirEmptyGameUseCase(teamRepository, youRepository),
+            AddTeamMemberUseCase(teamRepository, youRepository),
             CheckGameExistsUseCase(gameRepository),
             teamRepository
         )

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -34,6 +34,7 @@ import com.carkzis.ananke.utils.AddCurrentUserToTheirEmptyGameUseCase
 import com.carkzis.ananke.utils.AddTeamMemberUseCase
 import com.carkzis.ananke.utils.CheckGameExistsUseCase
 import com.carkzis.ananke.utils.GameStateUseCase
+import com.carkzis.ananke.utils.UserCharacterUseCase
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
@@ -253,6 +254,7 @@ class TeamScreenTest {
             GameStateUseCase(gameRepository),
             AddCurrentUserToTheirEmptyGameUseCase(teamRepository, youRepository),
             AddTeamMemberUseCase(teamRepository, youRepository),
+            UserCharacterUseCase(youRepository),
             CheckGameExistsUseCase(gameRepository),
             teamRepository
         )

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -276,6 +276,39 @@ class TeamScreenTest {
         }
     }
 
+    @Test
+    fun `view and dismiss dialogue of a team member`() = runTest {
+        composeTestRule.apply {
+            val viewModel = teamViewModel()
+
+            val game = CurrentGame("123")
+            gameRepository.emitCurrentGame(game)
+            teamRepository.emitUsers(dummyUsers())
+
+            initialiseTeamScreenViaTeamRoute(viewModel)
+
+            addHighestUserInListToTeam(
+                onCompletion = {
+                    gameRepository.emitGames(listOf(game.toGame()))
+                }
+            )
+
+            onAllNodesWithTag("${AnankeDestination.TEAM}-tm-card-box")
+                .onFirst()
+                .assertHasClickAction()
+                .performClick()
+
+            onNodeWithTag("${AnankeDestination.TEAM}-team-member-dialogue")
+                .assertIsDisplayed()
+
+            // Closing the dialogue manually as Roboletric is not seeing the close button.
+            viewModel.closeDialogue()
+
+            onNodeWithTag("${AnankeDestination.TEAM}-team-member-dialogue")
+                .assertIsNotDisplayed()
+        }
+    }
+
     private fun SemanticsNodeInteractionCollection.assertUsersInListHaveExpectedData(expectedUsers: List<User>) {
         fetchSemanticsNodes().forEachIndexed { index, _ ->
             val currentCard = get(index)

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -244,6 +244,7 @@ class TeamScreenTest {
             TeamRoute(
                 viewModel = viewModel,
                 onOutOfGame = onOutOfGame,
+                onShowSnackbar = { false }
             )
         }
     }

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasAnyChild
@@ -103,7 +104,7 @@ class TeamScreenTest {
             var redirected = false
             val viewModel = teamViewModel()
 
-            initialiseGameScreenViaTeamRoute(
+            initialiseTeamScreenViaTeamRoute(
                 viewModel,
                 onOutOfGame = { redirected = true }
             )
@@ -119,7 +120,7 @@ class TeamScreenTest {
             val viewModel = teamViewModel()
 
             var redirected = false
-            initialiseGameScreenViaTeamRoute(
+            initialiseTeamScreenViaTeamRoute(
                 viewModel,
                 onOutOfGame = { redirected = true }
             )
@@ -180,7 +181,7 @@ class TeamScreenTest {
             gameRepository.emitCurrentGame(game)
             teamRepository.emitUsers(dummyUsers())
 
-            initialiseGameScreenViaTeamRoute(viewModel)
+            initialiseTeamScreenViaTeamRoute(viewModel)
 
             onNodeWithTag("${AnankeDestination.TEAM}-team-column")
                 .assertExists()
@@ -248,6 +249,33 @@ class TeamScreenTest {
         }
     }
 
+    @Test
+    fun `view and dismiss dialogue of a user`() = runTest {
+        composeTestRule.apply {
+            val viewModel = teamViewModel()
+
+            val game = CurrentGame("123")
+            gameRepository.emitCurrentGame(game)
+            teamRepository.emitUsers(dummyUsers())
+
+            initialiseTeamScreenViaTeamRoute(viewModel)
+
+            onAllNodesWithTag("${AnankeDestination.TEAM}-user-name")
+                .onFirst()
+                .assertHasClickAction()
+                .performClick()
+
+            onNodeWithTag("${AnankeDestination.TEAM}-user-dialogue")
+                .assertIsDisplayed()
+
+            onNodeWithTag("${AnankeDestination.TEAM}-user-dialogue-close-button", useUnmergedTree = true)
+                .performClick()
+
+            onNodeWithTag("${AnankeDestination.TEAM}-user-dialogue")
+                .assertIsNotDisplayed()
+        }
+    }
+
     private fun SemanticsNodeInteractionCollection.assertUsersInListHaveExpectedData(expectedUsers: List<User>) {
         fetchSemanticsNodes().forEachIndexed { index, _ ->
             val currentCard = get(index)
@@ -295,7 +323,7 @@ class TeamScreenTest {
         }
     }
 
-    private fun initialiseGameScreenViaTeamRoute(
+    private fun initialiseTeamScreenViaTeamRoute(
         viewModel: TeamViewModel,
         onOutOfGame: () -> Unit = {},
         onShowSnackbar: suspend (String) -> Boolean = { false }

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamViewModelTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamViewModelTest.kt
@@ -4,7 +4,6 @@ import com.carkzis.ananke.data.database.toDomain
 import com.carkzis.ananke.data.model.CurrentGame
 import com.carkzis.ananke.data.model.Game
 import com.carkzis.ananke.data.model.GameCharacter
-import com.carkzis.ananke.data.model.NewCharacter
 import com.carkzis.ananke.data.model.User
 import com.carkzis.ananke.testdoubles.ControllableGameRepository
 import com.carkzis.ananke.testdoubles.ControllableTeamRepository
@@ -22,7 +21,6 @@ import com.carkzis.ananke.utils.GameStateUseCase
 import com.carkzis.ananke.utils.MainDispatcherRule
 import com.carkzis.ananke.utils.UserCharacterUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/com/carkzis/ananke/ui/TeamViewModelTest.kt
+++ b/app/src/test/java/com/carkzis/ananke/ui/TeamViewModelTest.kt
@@ -412,7 +412,7 @@ class TeamViewModelTest {
             }
         }
 
-        assertTrue(events.first() is TeamEvent.TeamMemberDialogueHidden)
+        assertTrue(events.first() is TeamEvent.CloseDialogue)
 
         collection.cancel()
     }
@@ -468,12 +468,34 @@ class TeamViewModelTest {
         }
 
         viewModel.viewCharacterForTeamMember(currentUser.toDomain())
-        viewModel.closeTeamMemberDialogue()
+        viewModel.closeDialogue()
 
         assertEquals(3, events.size)
-        assertTrue(events.first() is TeamEvent.TeamMemberDialogueHidden)
+        assertTrue(events.first() is TeamEvent.CloseDialogue)
         assertTrue(events[1] is TeamEvent.TeamMemberDialogueShow)
-        assertTrue(events.last() is TeamEvent.TeamMemberDialogueHidden)
+        assertTrue(events.last() is TeamEvent.CloseDialogue)
+
+        collection.cancel()
+    }
+
+    @Test
+    fun `view model sends event for current user when viewing requested`() = runTest {
+        val currentUser = dummyUserEntities.first()
+        val currentGame = CurrentGame("1", "A Title", "A Description", currentUser.userId.toString())
+
+        gameRepository.emitCurrentGame(currentGame)
+
+        val events = mutableListOf<TeamEvent>()
+        val collection = launch(UnconfinedTestDispatcher()) {
+            viewModel.event.collect {
+                events.add(it)
+            }
+        }
+
+        viewModel.viewUser(currentUser.toDomain())
+
+        val lastEvent = events.last() as TeamEvent.UserDialogueShow
+        assertTrue(lastEvent.user == currentUser.toDomain())
 
         collection.cancel()
     }


### PR DESCRIPTION
When a user is added to a game, a character is automatically added for them. Team members and users can be viewed by clicking on the cards, which opens up a dismissable dialogue with the relevant information. If they are in a team, character information is shown instead. They are not editable from the TeamScreen.